### PR TITLE
Update usage of reporter object to reflect new backend response

### DIFF
--- a/src/pages/admin/ReportDashboard.tsx
+++ b/src/pages/admin/ReportDashboard.tsx
@@ -52,6 +52,7 @@ const ReportDashboard = () => {
     getAllReport()
       .then((res) => {
         setReports(res);
+        devPrint(res);
       })
       .catch((error) => {
         devPrint(error);
@@ -71,7 +72,7 @@ const ReportDashboard = () => {
   const filteredReports = reports.filter((report) => {
     return (
       (!filterType || report.type === filterType) &&
-      (!filterUserId || report.reporterUserId === filterUserId) &&
+      (!filterUserId || report.reporter.id === filterUserId) &&
       report.reason.toLowerCase().includes(searchKeyword.toLowerCase())
     );
   });
@@ -142,14 +143,14 @@ const ReportDashboard = () => {
                     <VStack align="stretch" spacing={2}>
                       <HStack justify="space-between">
                         <Text>
-                          <Link to={`/directory/${report.reporterUserId}`}>
+                          <Link to={`/directory/${report.reporter.id}`}>
                             <strong>From user: </strong>
-                            {report.reporterUserId}
+                            {report.reporter.id}
                           </Link>
                         </Text>
                         <Button
                           as={Link}
-                          to={`/directory/${report.reporterUserId}`}
+                          to={`/directory/${report.reporter.id}`}
                           colorScheme="blue"
                           size="sm"
                         >

--- a/src/services/report.ts
+++ b/src/services/report.ts
@@ -2,10 +2,11 @@ import { devPrint } from '../components/utils/RandomUtils';
 import { parseAnyDate } from '../localization';
 import { RawReport, RawReportBody, Report, ReportBody } from '../types';
 import api from './api';
+import { deserializeMember } from './member';
 
 function deserializedReport({
   report_id: reportId,
-  reporter_user_id: reporterUserId,
+  reporter,
   admin_id: adminId,
   admin_notes: adminNotes,
   associated_id: associatedId,
@@ -17,7 +18,7 @@ function deserializedReport({
   return {
     ...rest,
     reportId,
-    reporterUserId,
+    reporter: deserializeMember(reporter),
     adminId,
     adminNotes,
     associatedId,

--- a/src/types.ts
+++ b/src/types.ts
@@ -210,7 +210,7 @@ export interface RawReport {
   created: string;
   reason: string;
   report_id: string;
-  reporter_user_id: number;
+  reporter: RawMemberData;
   status: ReportStatus;
   type: ReportType;
   updated: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -224,7 +224,7 @@ export interface Report {
   created: Date;
   reason: string;
   reportId: string;
-  reporterUserId: number;
+  reporter: Member;
   status: ReportStatus;
   type: ReportType;
   updated: Date;


### PR DESCRIPTION
Author: Advay

## What changes were made?

Change the frontend to use the new schema defined in [this PR](https://github.com/swecc-uw/swecc-server/pull/73).

## Why are these changes important/necessary?

The data returned in an API response is changing, so it's necessary to update its corresponding usage in the frontend accordingly to ensure the frontend doesn't break.
